### PR TITLE
feat: Add nemo-python

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -43,6 +43,7 @@
                 "nemo-fileroller",
                 "nemo-image-converter",
                 "nemo-preview",
+                "nemo-python",
                 "nm-connection-editor",
                 "paper-icon-theme",
                 "pipewire-alsa",


### PR DESCRIPTION
Needed for Nemo file manager Python extension integration.

Also needed for popular GSConnect extension, for "Send to mobile device" context menu.

Issue: https://github.com/ublue-os/main/issues/394